### PR TITLE
Fix plus to zoom in on US keyboard layout

### DIFF
--- a/GpsMaster/src/org/gpsmaster/GpsMaster.java
+++ b/GpsMaster/src/org/gpsmaster/GpsMaster.java
@@ -698,6 +698,9 @@ public class GpsMaster extends JComponent {
         // keyboard +
         mapPanel.getInputMap(JComponent.WHEN_FOCUSED).put(
                 KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, 0), zoomIn);
+        // keyboard + (US layout)
+        mapPanel.getInputMap(JComponent.WHEN_FOCUSED).put(
+                KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, KeyEvent.SHIFT_DOWN_MASK), zoomIn);
         // numpad +
         mapPanel.getInputMap(JComponent.WHEN_FOCUSED).put(
                 KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0), zoomIn);


### PR DESCRIPTION
For the US keyboard layout, plus is typed with VK_EQUAL and SHIFT_DOWN_MASK.

See [this stack overflow answer](https://stackoverflow.com/a/15605195/3179747).