### PR TITLE
Fix GpsMaster/createJAR.sh

### DIFF
--- a/GpsMaster/createJAR.sh
+++ b/GpsMaster/createJAR.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 rm -rf GpsMaster_jar
 mkdir -p GpsMaster_jar/org/gpsmaster/ &&
-rsync  bin/org/gpsmaster/*.txt GpsMaster_jar/org/gpsmaster/ &&
+rsync  bin/org/gpsmaster/info/*.txt GpsMaster_jar/org/gpsmaster/info &&
 rsync -ar external/ GpsMaster_jar/ &&
 rsync -ar src/* GpsMaster_jar/ --exclude=*.java &&
 JVER=$(javac -version 2>&1 ) &&


### PR DESCRIPTION
We still have an old way to build with an old JDK 8.
The binary will run under JDK8 (possibly 7), 9, 10.
Everybody using Java 11 and higher should use the binary for JDK11,
which is generated with mvn.
Before we kick out the old JDK8 for good, fix the script and
postpone the cleanup a little bit.