### PR TITLE
routes: insert and move waypoints - system out estimated hiking time

### DIFF
--- a/GpsMaster/src/org/gpsmaster/gpxpanel/Route.java
+++ b/GpsMaster/src/org/gpsmaster/gpxpanel/Route.java
@@ -3,8 +3,8 @@ package org.gpsmaster.gpxpanel;
 import java.awt.Color;
 import java.util.Enumeration;
 import java.util.HashMap;
-
 import javax.swing.tree.TreeNode;
+import java.math.*;
 
 import org.gpsmaster.gpxpanel.WaypointGroup.WptGrpType;
 
@@ -20,6 +20,7 @@ public class Route extends GPXObjectCommon {
 
     protected int number;
     protected String type;
+    protected double estHikeHours = 0;
 
     private WaypointGroup path;
 
@@ -67,6 +68,16 @@ public class Route extends GPXObjectCommon {
     	return path.getNumPts();
     }
 
+    public double getEstHikeHours() {
+    	return estHikeHours;
+    }
+
+    public String getEstHikeHoursString() {
+    	long hrs = Math.round(Math.floor(estHikeHours));
+    	long mns = Math.round((estHikeHours - hrs) * 60);
+    	return String.valueOf(hrs) + ":" + String.format("%02d", mns) + " h";
+    }
+
     /* (non-Javadoc)
      * @see org.gpsmaster.gpxpanel.GPXObject#updateAllProperties()
      */
@@ -100,6 +111,25 @@ public class Route extends GPXObjectCommon {
                 }
                 meta.values.addAll(pathMeta.values);
             }
+        }
+        
+        // calculate the estimated duration of a hike and system out it if it has changed.
+        // formula according to alpenverein austria
+        // https://www.alpenverein.at/portal/news/aktuelle_news_kurz/2018/2018_06_14_wie-berechnet-man-die-gehzeit-auf-wanderwegen.php
+        // todo: parameters (300, 500, 4) -> config file so one can adjust to own fitness level and experience 
+        // todo: presets for strolling, hiking, fast hiking, running...
+        // todo: show this value in property table of routes
+        String compStr = getEstHikeHoursString();
+        double vertTime = (grossRiseMeters / 300) + (grossFallMeters / 500);
+        double horzTime = (lengthMeters / 1000) / 4;
+        if (horzTime >= vertTime) {
+        	estHikeHours = horzTime + (vertTime / 2);
+        }
+        else {
+        	estHikeHours = vertTime + (horzTime / 2);
+        }
+        if (!getEstHikeHoursString().equals(compStr)) {
+        	System.out.println("estHikeHours: " + getEstHikeHoursString());
         }
 
         extToColor();

--- a/GpsMaster/src/org/gpsmaster/gpxpanel/WaypointGroup.java
+++ b/GpsMaster/src/org/gpsmaster/gpxpanel/WaypointGroup.java
@@ -92,7 +92,25 @@ public class WaypointGroup extends GPXObjectND implements Comparable<WaypointGro
      * Adds a waypoint to the group.
      */
     public void addWaypoint(Waypoint wpt) {
-        waypoints.add(wpt);
+   		waypoints.add(wpt);
+    }
+
+    /**
+     * Inserts a waypoint to the group right after the active waypoint
+     */
+  
+    public void insertWaypoint(Waypoint actwpt, Waypoint wpt) {
+    	int idx = -1;
+    	if ((actwpt != null)) {
+    		idx = waypoints.indexOf(actwpt) + 1;
+    	}
+    	
+    	if (idx >= 0) {
+    		waypoints.add(idx, wpt);
+    	} 
+    	else {
+    		waypoints.add(wpt);
+    	}
     }
 
     /**

--- a/GpsMaster/src/org/gpsmaster/painter/TrackPainter.java
+++ b/GpsMaster/src/org/gpsmaster/painter/TrackPainter.java
@@ -8,6 +8,7 @@ import java.awt.Stroke;
 import java.awt.geom.GeneralPath;
 import java.util.List;
 
+import org.gpsmaster.ActiveGpxObjects;
 import org.gpsmaster.gpxpanel.GPXFile;
 import org.gpsmaster.gpxpanel.Route;
 import org.gpsmaster.gpxpanel.Track;
@@ -28,6 +29,7 @@ public class TrackPainter extends Painter {
 
 	private final int ORDER = 0;
 
+	public static ActiveGpxObjects active = null;
 	/**
 	 *
 	 */
@@ -172,15 +174,21 @@ public class TrackPainter extends Painter {
      * Paints the pathpoints for a path in {@link WaypointGroup}.
      */
     private void paintPathpoints(Graphics2D g2d, WaypointGroup wptGrp) {
+        
         if (wptGrp.isVisible() && wptGrp.isTrackPtsVisible()) {
-        	g2d.setColor(Color.BLACK);
+            Stroke saveStroke = g2d.getStroke();
+        	g2d.setStroke(new BasicStroke(2.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+        	g2d.setColor(Color.DARK_GRAY);
 
             for (Waypoint wpt : wptGrp.getWaypoints()) {
                 Point point = mapViewer.getMapPosition(wpt.getLat(), wpt.getLon(), false);
+            	if (wpt == active.getRoutepoint()) {g2d.setColor(Color.BLUE);}
+            	else {g2d.setColor(Color.DARK_GRAY);}
                 if (mapViewer.getBounds().contains(point)) {
                 	g2d.drawOval(point.x-2, point.y-2, 4, 4);
                 }
             }
+            g2d.setStroke(saveStroke);
         }
         // System.out.println(String.format("%d %d %d %d", getBounds().x, getBounds().y, getBounds().width, getBounds().y));
     }

--- a/GpsMaster/src/org/gpsmaster/undo/UndoMoveWaypoint.java
+++ b/GpsMaster/src/org/gpsmaster/undo/UndoMoveWaypoint.java
@@ -1,0 +1,44 @@
+package org.gpsmaster.undo;
+
+import org.gpsmaster.gpxpanel.Waypoint;
+import org.gpsmaster.gpxpanel.WaypointGroup;
+
+/**
+ *
+ * @author wbeisser
+ *
+ */
+public class UndoMoveWaypoint implements IUndoable {
+
+	protected Waypoint wpt = null;
+	protected WaypointGroup group = null;
+	protected double lat;
+	protected double lon;
+
+	/**
+	 *
+	 * @param wpt waypoint to be re-added
+	 * @param waypointGroup {@link WaypointGroup] containing {@link Waypoint} to be re-added
+	 */
+	public UndoMoveWaypoint(Waypoint wpt, WaypointGroup waypointGroup) {
+		this.wpt = wpt;
+		this.group = waypointGroup;
+		this.lat = wpt.getLat();
+		this.lon = wpt.getLon();
+	}
+
+	@Override
+	public String getUndoDescription() {
+		String desc = String.format("Move Point (%.6f, %.6f)", lat, lon);
+		return desc;
+	}
+
+	@Override
+	public void undo() {
+		if (this.wpt != null) {
+			this.wpt.setLat(this.lat);
+			this.wpt.setLon(this.lon);
+		}
+	}
+
+}


### PR DESCRIPTION
-     i've introduced a activeRoutepoint to the ActiveGpxObjects
-     whenever you move the mouse over a route point of the active route this Waypoint is stored in activeRoutepoint
-     this route point is marked with a blue circle instead of a black one. if isTrackPtsVisible is set to true.
-     route points are little circles now.
-     if you insert a route point it is inserted after the activeRoutepoint and the new inserted route point is the new activeRoutepoint.
-     to move the current activeRoutepoint, hold down the ctrl key and the activeRoutepoint is moved to the new location instead of a new route point being created.
-     new: UndoMoveWaypoint
-     as a bonus i've also added estHikeHours to routes. it stores the estimated hiking time in hours according to official formula for hiking routes. if it changes (due to editing route points or refreshing elevation data), it will system out the value (h:mm).